### PR TITLE
Inhibit send-tty call on non-TTYs

### DIFF
--- a/bracketed-paste.el
+++ b/bracketed-paste.el
@@ -128,7 +128,8 @@
   '(suspend-hook suspend-tty-functions kill-emacs-hook delete-frame-functions))
 
 (defun bracketed-paste--safe-tty-state-call (terminalish send-tty)
-  (cond ((null terminalish) (funcall send-tty))
+  (cond ((window-system) nil) ; don't call send-tty if not a TTY
+        ((null terminalish) (funcall send-tty))
         ((and (eq (terminal-live-p terminalish) t) ; borrowed from xt-mouse.el
               (not (string= (terminal-name terminalish) "initial_terminal")))
          (funcall send-tty terminalish))))


### PR DESCRIPTION
Calling `send-tty` on a frame which is displayed on a window system causes an error:

```
apply: Device 1 is not a termcap terminal device
```

Only call `send-tty` when `(window-system)` is `nil`.

Fixes #2 
